### PR TITLE
Add more sensible errors

### DIFF
--- a/src/definition/parse.ts
+++ b/src/definition/parse.ts
@@ -71,7 +71,11 @@ export default class DefinitionParser {
     return flow(
       (data: any) =>
         mapValues(data, (value, key) => {
+          if( typeof value.action_id === 'undefined') 
+            throw new Error(`Field "action_id" is missing from presentation "${key}"`);
           const definition = definitions[value.action_id];
+          if( typeof definition === 'undefined') 
+            throw new Error(`Action "${value.action_id}" is missing from presentation "${key}"`);
           return {
             id: key,
             action: {


### PR DESCRIPTION
I added validation checks for the definitions in regards to the action linking, to both check you have the correct field (action_id) and that the definition actually exists.

We could probably add a few more of these or do it in a more correct way but thought I would throw this here now and see what the best solution is, or maybe we just merge this at some point.