### PR TITLE
Add support for configuring plugins with values from settings

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -4,7 +4,7 @@ import { DefinitionParser } from '../definition';
 import ALSProvider, { IALSProvider } from '../als/als';
 import ALS from '../als';
 import { DataFactory } from '../als/data';
-
+import { Setting } from './pluginHelpers';
 /**
  * Create a default app configuration
  */
@@ -26,4 +26,4 @@ export default function createApp(
   return app;
 }
 
-export { App };
+export { App, Setting };

--- a/src/app/pluginHelpers.test.ts
+++ b/src/app/pluginHelpers.test.ts
@@ -1,0 +1,44 @@
+import { resolveSettings, Setting } from "./pluginHelpers";
+
+const app = {
+  configuration: () => ({
+    TEST: 'a',
+    TEST2: 'b',
+  }),
+};
+
+
+describe('The resolveSettings function', () => {
+  it('Should return an empty object when passed an empty object', async () => {
+    const result = await resolveSettings(app as any, {});
+    expect(result).toMatchObject({});
+  });
+
+  it('Should return config options which are not settings', async () => {
+    const result = await resolveSettings(app as any, { test: 'hello' });
+    expect(result).toMatchObject({ test: 'hello' });
+  });
+
+  it('Should return the config value for a setting', async () => {
+    const result = await resolveSettings(app as any, { test: Setting('TEST') });
+    expect(result).toMatchObject({ test: 'a' });
+  });
+
+  it('Should return the combination of plain settings, and config settings', async () => {
+    const result = await resolveSettings(app as any, {
+      test1: 'test',
+      test2: Setting('TEST')
+    });
+    expect(result).toMatchObject({ test1: 'test', test2: 'a' });
+  });
+
+  it('Should return undefined for missing settings', async () => {
+    const result = await resolveSettings(app as any, { missing: Setting('missing') });
+    expect(result.missing).toBeUndefined();
+  });
+
+  it('Should return the default value for missing settings', async () => {
+    const result = await resolveSettings(app as any, { missing: Setting('missing', 'default') });
+    expect(result.missing).toBe('default');
+  });
+});

--- a/src/app/pluginHelpers.ts
+++ b/src/app/pluginHelpers.ts
@@ -1,0 +1,30 @@
+import { pickBy, reduce } from 'lodash';
+import { IApp } from "./app";
+
+export const SETTING = Symbol("SETTING");
+
+type SettingT = {
+  tag: Symbol,
+  name: string,
+  defaultValue: any,
+};
+
+export const Setting = (name: string, defaultValue?: any): SettingT => ({
+  tag: SETTING,
+  name,
+  defaultValue,
+});
+
+export const resolveSettings = async (app: IApp, config: { [i: string]: any }) => {
+  const toResolve = pickBy(config, value => value.tag === SETTING);
+  const results = await app.configuration(...Object.values(toResolve).map(o => o.name))
+  const resolved = reduce(toResolve, (result, value, key) => {
+    const resolvedValue = results[value.name];
+    result[key] = resolvedValue ? resolvedValue : value.defaultValue;
+    return result;
+  }, {} as { [i: string]: any});
+  return {
+    ...config,
+    ...resolved
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import createApp from './app';
 
-export { default as createApp, App } from './app';
+export { default as createApp, App, Setting } from './app';
 
 export { Communicator, createUrlCommunicator } from './communicator';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
         "sourceMap": true,
         "lib": [
             "dom",
-            "es2016"
+            "es2016",
+            "esnext"
         ]
     },
     "include": [


### PR DESCRIPTION
More importantly this achieves the above without having to make
breaking changes to the plugin api to support promises.

Ideally the configure, customise and use calls for the plugin api
would support Promise<T> instead of T through the whole process but
this is not currently the case and would be a breaking change.

This system allows configuration via settings / config while only
requiring that use return a promise, which is already supported.

This does require that plugins are coded to call resolveSettings
but this is a relatively easy change, and will be demonstrated in
ubiquity-client.

Usage (for the IWA) would be:
```
UbiquityPlugin.configure(default => ({
    ...default,
    baseUrl: Setting('UBIQUITY_BASE_URL')
});
```