### PR TITLE
fix for opening external links

### DIFF
--- a/src/messages/launch.test.ts
+++ b/src/messages/launch.test.ts
@@ -40,13 +40,13 @@ describe('Launch domain messages', () => {
 
     it('Sets external false by default', () => {
       const message = browser('https://example.com');
-      expect(message.data.settings.external).toBeFalsy();
+      expect(message.data.settings.launch_type).toBe('default');
     });
 
     it('Sets external true when set', () => {
       const message = browser('https://example.com', true);
-      expect(message.data.settings.external).toBeDefined();
-      expect(message.data.settings.external).toBeTruthy();
+      expect(message.data.settings.launch_type).toBeDefined();
+      expect(message.data.settings.launch_type).toBe('external');
     });
   });
 });

--- a/src/messages/launch.ts
+++ b/src/messages/launch.ts
@@ -33,7 +33,7 @@ export const browser = (url: string, external = false) => ({
   data: {
     url,
     settings: {
-      external,
+      launch_type: external ? 'external' : 'default',
     },
   },
 });


### PR DESCRIPTION
External links were not working for me and @cyrildoussin mentioned to me yesterday the property on `settings` should be `launch_type` not `external`. I've tested it using the iOS emulator but not on Android.